### PR TITLE
Automate releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,45 @@
+name: Create release
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Execute Gradle jar
+        run: |
+          chmod +x ./gradlew
+          ./gradlew jar
+
+      - name: Store build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: exercisegenerator.jar
+          path: exercisegenerator.jar
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v2.1.1
+
+      - name: Create Release With Asset
+        id: Release-AIO
+        uses: Hs1r1us/Release-AIO@v2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          asset_files: './exercisegenerator.jar'


### PR DESCRIPTION
The GitHub workflow added here watches for new Git tags and creates a release for any new tag. It will also build the `exercisegenerator.jar` and attach it to the release as an asset. The release will be named after the tag. In order for this action to work a secret `RELEASE_TOKEN` has to be created for the repository. I tested this with a PAT with full access to the repository.